### PR TITLE
Implemented full Spring Security integration including authentication, authorization, and role-based UI visibility.

### DIFF
--- a/Umbrella/pom.xml
+++ b/Umbrella/pom.xml
@@ -15,7 +15,7 @@
 	<description>Umbrella App</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 
 	<dependencies>
@@ -43,6 +43,15 @@
 			<artifactId>mysql-connector-java</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-springsecurity5</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/Umbrella/src/main/java/com/goncha/umbrella/controller/UserController.java
+++ b/Umbrella/src/main/java/com/goncha/umbrella/controller/UserController.java
@@ -7,6 +7,7 @@ import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -44,6 +45,7 @@ public class UserController {
 		return "user/view";
 	}
 
+	@PreAuthorize("hasRole('ADMIN')")
 	@PostMapping({"", "/"})
 	public String createUser(@Valid @ModelAttribute("user") User user, BindingResult result, Model model) {
 		if (result.hasErrors()) {
@@ -70,6 +72,7 @@ public class UserController {
 		return "user/view";
 	}
 
+	@PreAuthorize("hasRole('ADMIN')")
 	@PutMapping("/{id}")
 	public String putEditUser(@PathVariable Long id, @Valid @ModelAttribute("user") User user,
 			BindingResult result, Model model) {
@@ -92,6 +95,7 @@ public class UserController {
 		return "user/view";
 	}
 
+	@PreAuthorize("hasRole('ADMIN')")
 	@DeleteMapping("/{id}")
 	@ResponseBody
 	public ResponseEntity<Map<String, String>> deleteUser(@PathVariable Long id) {
@@ -106,6 +110,7 @@ public class UserController {
 		return ResponseEntity.ok(result);
 	}
 
+	@PreAuthorize("hasRole('ADMIN')")
 	@PatchMapping("/{id}/password")
 	@ResponseBody
 	public ResponseEntity<Map<String, String>> changePassword(

--- a/Umbrella/src/main/java/com/goncha/umbrella/converter/RoleToStringConverter.java
+++ b/Umbrella/src/main/java/com/goncha/umbrella/converter/RoleToStringConverter.java
@@ -1,0 +1,15 @@
+package com.goncha.umbrella.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import com.goncha.umbrella.entity.Role;
+
+@Component
+public class RoleToStringConverter implements Converter<Role, String> {
+
+	@Override
+	public String convert(Role role) {
+		return String.valueOf(role.getId());
+	}
+}

--- a/Umbrella/src/main/java/com/goncha/umbrella/entity/User.java
+++ b/Umbrella/src/main/java/com/goncha/umbrella/entity/User.java
@@ -1,7 +1,6 @@
 package com.goncha.umbrella.entity;
 
 import java.io.Serializable;
-import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -9,12 +8,11 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
-import javax.persistence.JoinColumn;
 
 import org.hibernate.annotations.GenericGenerator;
 
@@ -55,12 +53,9 @@ public class User implements Serializable {
 	@Transient 
 	private String confirmPassword;
 	
-	@ManyToMany(fetch = FetchType.LAZY)
-	@JoinTable(name="user_roles"
-		,joinColumns=@JoinColumn(name="user_id")
-		,inverseJoinColumns=@JoinColumn(name="role_id"))
-	
-	private Set<Role> roles;
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "role_id")
+	private Role role;
 	
 	public User() {	}
 	
@@ -132,12 +127,12 @@ public class User implements Serializable {
 		this.confirmPassword = confirmPassword;
 	}
 
-	public Set<Role> getRoles() {
-		return roles;
+	public Role getRole() {
+		return role;
 	}
 
-	public void setRoles(Set<Role> roles) {
-		this.roles = roles;
+	public void setRole(Role role) {
+		this.role = role;
 	}
 
 	public static long getSerialversionuid() {
@@ -155,7 +150,7 @@ public class User implements Serializable {
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
 		result = prime * result + ((lastName == null) ? 0 : lastName.hashCode());
 		result = prime * result + ((password == null) ? 0 : password.hashCode());
-		result = prime * result + ((roles == null) ? 0 : roles.hashCode());
+		result = prime * result + ((role == null) ? 0 : role.hashCode());
 		result = prime * result + ((username == null) ? 0 : username.hashCode());
 		return result;
 	}
@@ -204,10 +199,10 @@ public class User implements Serializable {
 				return false;
 		} else if (!password.equals(other.password))
 			return false;
-		if (roles == null) {
-			if (other.roles != null)
+		if (role == null) {
+			if (other.role != null)
 				return false;
-		} else if (!roles.equals(other.roles))
+		} else if (!role.equals(other.role))
 			return false;
 		if (username == null) {
 			if (other.username != null)
@@ -221,7 +216,7 @@ public class User implements Serializable {
 	public String toString() {
 		return "User [id=" + id + ", enabled=" + enabled + ", firstName=" + firstName + ", lastName=" + lastName
 				+ ", email=" + email + ", username=" + username + ", password=" + password + ", confirmPassword="
-				+ confirmPassword + ", roles=" + roles + "]";
+				+ confirmPassword + ", role=" + role + "]";
 	}     
 	
 }

--- a/Umbrella/src/main/java/com/goncha/umbrella/repository/RoleRepository.java
+++ b/Umbrella/src/main/java/com/goncha/umbrella/repository/RoleRepository.java
@@ -1,5 +1,7 @@
 package com.goncha.umbrella.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,6 @@ import com.goncha.umbrella.entity.Role;
 
 @Repository
 public interface RoleRepository extends CrudRepository<Role, Long> {
+
+	Optional<Role> findByName(String name);
 }

--- a/Umbrella/src/main/java/com/goncha/umbrella/security/PasswordMigrationRunner.java
+++ b/Umbrella/src/main/java/com/goncha/umbrella/security/PasswordMigrationRunner.java
@@ -1,0 +1,43 @@
+package com.goncha.umbrella.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import com.goncha.umbrella.entity.User;
+import com.goncha.umbrella.repository.UserRepository;
+
+/**
+ * Runs once on startup and migrates plain-text passwords to BCrypt.
+ * Safe to run multiple times: BCrypt hashes always start with "$2" so
+ * already-encoded passwords are skipped automatically.
+ */
+@Component
+public class PasswordMigrationRunner implements CommandLineRunner {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	@Override
+	public void run(String... args) {
+		int migrated = 0;
+		for (User user : userRepository.findAll()) {
+			String pwd = user.getPassword();
+			if (pwd != null && !pwd.startsWith("$2")) {
+				user.setPassword(passwordEncoder.encode(pwd));
+				userRepository.save(user);
+				System.out.println("[PasswordMigration] Migrated password for user: " + user.getUsername());
+				migrated++;
+			}
+		}
+		if (migrated > 0) {
+			System.out.println("[PasswordMigration] Done. " + migrated + " password(s) migrated to BCrypt.");
+		} else {
+			System.out.println("[PasswordMigration] All passwords are already BCrypt. Nothing to do.");
+		}
+	}
+}

--- a/Umbrella/src/main/java/com/goncha/umbrella/security/RoleInitializer.java
+++ b/Umbrella/src/main/java/com/goncha/umbrella/security/RoleInitializer.java
@@ -1,0 +1,67 @@
+package com.goncha.umbrella.security;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import com.goncha.umbrella.entity.Role;
+import com.goncha.umbrella.repository.RoleRepository;
+
+@Component
+@Order(1)
+public class RoleInitializer implements CommandLineRunner {
+
+	private static final List<String> VALID_ROLES = Arrays.asList(
+		"ROLE_ADMIN", "ROLE_DOCTOR", "ROLE_NURSE",
+		"ROLE_RECEPTIONIST", "ROLE_PHARMACIST", "ROLE_ANALYST"
+	);
+
+	@Autowired
+	private RoleRepository roleRepository;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Override
+	public void run(String... args) {
+		cleanupLegacyRoles();
+
+		createIfNotExists("ROLE_ADMIN",        "Administrador");
+		createIfNotExists("ROLE_DOCTOR",       "Doctor");
+		createIfNotExists("ROLE_NURSE",        "Enfermero/a");
+		createIfNotExists("ROLE_RECEPTIONIST", "Recepcionista");
+		createIfNotExists("ROLE_PHARMACIST",   "Farmacéutico");
+		createIfNotExists("ROLE_ANALYST",      "Analista");
+
+		System.out.println("[RoleInitializer] Roles ready.");
+	}
+
+	private void cleanupLegacyRoles() {
+		String inClause = VALID_ROLES.stream()
+				.map(n -> "'" + n + "'")
+				.collect(Collectors.joining(", "));
+
+		int deleted = jdbcTemplate.update(
+			"DELETE FROM role WHERE name NOT IN (" + inClause + ")"
+		);
+		if (deleted > 0) {
+			System.out.println("[RoleInitializer] Removed " + deleted + " legacy role(s).");
+		}
+	}
+
+	private void createIfNotExists(String name, String description) {
+		if (roleRepository.findByName(name).isEmpty()) {
+			Role role = new Role();
+			role.setName(name);
+			role.setDescription(description);
+			roleRepository.save(role);
+			System.out.println("[RoleInitializer] Created role: " + name);
+		}
+	}
+}

--- a/Umbrella/src/main/java/com/goncha/umbrella/security/SecurityConfig.java
+++ b/Umbrella/src/main/java/com/goncha/umbrella/security/SecurityConfig.java
@@ -1,0 +1,53 @@
+package com.goncha.umbrella.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+	@Autowired
+	private UserDetailsServiceImpl userDetailsService;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Override
+	protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+		auth.userDetailsService(userDetailsService)
+				.passwordEncoder(passwordEncoder());
+	}
+
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http
+			.authorizeRequests()
+				.antMatchers("/", "/login", "/css/**", "/js/**", "/img/**").permitAll()
+				.anyRequest().authenticated()
+			.and()
+			.formLogin()
+				.loginPage("/login")
+				.defaultSuccessUrl("/home", true)
+				.failureUrl("/login?error=true")
+				.permitAll()
+			.and()
+			.logout()
+				.logoutUrl("/logout")
+				.logoutSuccessUrl("/login?logout=true")
+				.invalidateHttpSession(true)
+				.deleteCookies("JSESSIONID")
+				.permitAll();
+	}
+}

--- a/Umbrella/src/main/java/com/goncha/umbrella/security/UserDetailsServiceImpl.java
+++ b/Umbrella/src/main/java/com/goncha/umbrella/security/UserDetailsServiceImpl.java
@@ -1,0 +1,42 @@
+package com.goncha.umbrella.security;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.goncha.umbrella.entity.User;
+import com.goncha.umbrella.repository.UserRepository;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Override
+	@Transactional
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		User user = userRepository.findByUsername(username)
+				.orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+		Set<GrantedAuthority> authorities = new HashSet<>();
+		if (user.getRole() != null) {
+			authorities.add(new SimpleGrantedAuthority(user.getRole().getName()));
+		}
+
+		return org.springframework.security.core.userdetails.User.builder()
+				.username(user.getUsername())
+				.password(user.getPassword())
+				.authorities(authorities)
+				.disabled(!Boolean.TRUE.equals(user.getEnabled()))
+				.build();
+	}
+}

--- a/Umbrella/src/main/java/com/goncha/umbrella/service/impl/UserServiceImpl.java
+++ b/Umbrella/src/main/java/com/goncha/umbrella/service/impl/UserServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.goncha.umbrella.entity.User;
@@ -17,6 +18,9 @@ public class UserServiceImpl implements UserService{
 	@Autowired
 	UserRepository repository;
 
+	@Autowired
+	PasswordEncoder passwordEncoder;
+
 	@Override
 	public Iterable<User> getAllUser() {
 		return repository.findAll();
@@ -24,7 +28,8 @@ public class UserServiceImpl implements UserService{
 	
 	@Override
 	public User createUser(@Valid User user) throws Exception {
-		if(checkUsernameAvailale(user) && checkPassworodValid(user)) {
+		if(checkUsernameAvailable(user) && checkPassworodValid(user)) {
+			user.setPassword(passwordEncoder.encode(user.getPassword()));
 			repository.save(user);
 		}
 		return null;
@@ -54,23 +59,18 @@ public class UserServiceImpl implements UserService{
 		
 	}
 
-	private boolean checkUsernameAvailale(User user) throws Exception{
-
-		Optional<User> userFound = repository.findByUsername(user.getUsername());
-
-		if(userFound.isPresent()) {
-			
-			throw new Exception("Username not available");
-			
-		}
-
-		return !userFound.isPresent();
+	private boolean checkUsernameAvailable(User user) throws Exception{
+        repository.findByUsername(user.getUsername())
+                .map(usr -> {
+                    throw new IllegalStateException("Username not available");
+                });
+        return true;
 	}
 
 	private boolean checkPassworodValid(User user) throws Exception {
 
 		if(user.getConfirmPassword() == null || user.getConfirmPassword().isEmpty()) 
-			throw new Exception("Corfirm password can not be empty");
+			throw new Exception("Confirm password can not be empty");
 		
 		boolean isValid = user.getPassword().equals(user.getConfirmPassword());
 		
@@ -91,7 +91,7 @@ public class UserServiceImpl implements UserService{
 		if (!newPassword.equals(confirmPassword))
 			throw new Exception("Passwords do not match");
 		User user = getUserById(id);
-		user.setPassword(newPassword);
+		user.setPassword(passwordEncoder.encode(newPassword));
 		repository.save(user);
 	}
 
@@ -100,8 +100,8 @@ public class UserServiceImpl implements UserService{
 		to.setFirstName(from.getFirstName());
 		to.setLastName(from.getLastName());
 		to.setEmail(from.getEmail());
-		to.setRoles(from.getRoles());
 		to.setEnabled(from.getEnabled());
+		to.setRole(from.getRole());
 	}
 	
 }

--- a/Umbrella/src/main/resources/templates/home.html
+++ b/Umbrella/src/main/resources/templates/home.html
@@ -1,8 +1,11 @@
 <!DOCTYPE html>
-<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<html lang="es" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="_csrf" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
     <title>Umbrella Corp. | Dashboard</title>
     <script type="text/javascript" th:src="@{/js/common/jquery.js}"></script>
     <link rel="stylesheet" th:href="@{/css/common/bootstrap.min.css}"/>
@@ -262,8 +265,9 @@
             <i class="fas fa-hospital"></i> Hospitales <span class="badge-soon">Pronto</span>
         </a>
 
-        <div class="sidebar-section">Admin</div>
-        <a href="#" class="nav-item-side" data-module="usuarios" data-load="/user">
+        <div class="sidebar-section" sec:authorize="hasAnyRole('ADMIN', 'ANALYST')">Admin</div>
+        <a href="#" class="nav-item-side" data-module="usuarios" data-load="/user"
+           sec:authorize="hasAnyRole('ADMIN', 'ANALYST')">
             <i class="fas fa-users-cog"></i> Usuarios
         </a>
         <a href="#" class="nav-item-side" style="opacity:0.4; cursor:default;">
@@ -273,9 +277,10 @@
 
     <div class="sidebar-footer">
         <div class="sidebar-user">
-            <div class="avatar-circle">A</div>
+            <div class="avatar-circle"
+                 th:text="${#strings.toUpperCase(#strings.substring(#authentication.name, 0, 1))}">A</div>
             <div>
-                <div class="user-name">Admin</div>
+                <div class="user-name" sec:authentication="name">Admin</div>
                 <div class="user-role">Administrador</div>
             </div>
         </div>
@@ -335,6 +340,13 @@
 
 <script>
     var dashboardHTML = null;
+
+    // Attach CSRF token to every AJAX request (required for DELETE, PATCH, PUT)
+    var csrfToken  = $("meta[name='_csrf']").attr("content");
+    var csrfHeader = $("meta[name='_csrf_header']").attr("content");
+    $(document).ajaxSend(function (e, xhr) {
+        xhr.setRequestHeader(csrfHeader, csrfToken);
+    });
 
     $(document).ready(function () {
         dashboardHTML = $('#dashboard-view').html();

--- a/Umbrella/src/main/resources/templates/index.html
+++ b/Umbrella/src/main/resources/templates/index.html
@@ -23,12 +23,18 @@
 				<div class="col-12 avatar-img">
 					<img th:src="@{/img/login/racoon.png}" />
 				</div>
-				<form class="col-12" action="">
+				<form class="col-12" th:action="@{/login}" method="post">
+					<div th:if="${param.error}" class="alert alert-danger py-2" style="font-size:0.82rem;">
+						Usuario o contraseña incorrectos.
+					</div>
+					<div th:if="${param.logout}" class="alert alert-success py-2" style="font-size:0.82rem;">
+						Sesión cerrada exitosamente.
+					</div>
 					<div class="form-group" id="user-group">
-						<input type="text" class="form-control" placeholder="Access Code">
+						<input type="text" name="username" class="form-control" placeholder="Access Code" autocomplete="username">
 					</div>
 					<div class="form-group" id="pwd-group">
-						<input type="password" class="form-control" placeholder="Security Key">
+						<input type="password" name="password" class="form-control" placeholder="Security Key" autocomplete="current-password">
 					</div>
 					<button type="submit" class="btn btn-danger sign-in"><i class="fas fa-sign-in-alt"></i>  Sign in</button>
 				</form>

--- a/Umbrella/src/main/resources/templates/user/view.html
+++ b/Umbrella/src/main/resources/templates/user/view.html
@@ -164,7 +164,8 @@
             <div style="font-size:1.1rem; font-weight:700; color:#fff;">Usuarios</div>
             <div style="font-size:0.75rem; color:#666;">Gestión de usuarios del sistema</div>
         </div>
-        <button class="btn-add" id="btnToggleForm" onclick="toggleUserForm()">
+        <button class="btn-add" id="btnToggleForm" onclick="toggleUserForm()"
+                sec:authorize="hasRole('ADMIN')">
             <span class="btn-icon"><i class="fas fa-plus"></i></span>
             Agregar Usuario
         </button>
@@ -222,9 +223,13 @@
                             <div class="field-error" th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></div>
                         </div>
                         <div class="col-md-6 form-group">
-                            <label class="um-label">Roles</label>
-                            <select class="um-input" size="3" multiple th:field="*{roles}">
-                                <option th:each="role : ${roles}" th:value="${role.id}" th:text="${role.name}"></option>
+                            <label class="um-label">Rol</label>
+                            <select class="um-input" th:field="*{role}">
+                                <option value="">-- Sin rol --</option>
+                                <option th:each="r : ${roles}"
+                                        th:value="${r.id}"
+                                        th:text="${r.description}">
+                                </option>
                             </select>
                         </div>
                     </div>
@@ -252,7 +257,7 @@
                         <th>Username</th>
                         <th>Email</th>
                         <th>Estado</th>
-                        <th></th>
+                        <th sec:authorize="hasRole('ADMIN')"></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -266,7 +271,7 @@
                             <span th:if="${user.enabled}" class="badge-active">Activo</span>
                             <span th:unless="${user.enabled}" class="badge-inactive">Inactivo</span>
                         </td>
-                        <td style="white-space:nowrap;">
+                        <td style="white-space:nowrap;" sec:authorize="hasRole('ADMIN')">
                             <a class="action-btn" href="#"
                                th:onclick="'editUser(' + ${user.id} + '); return false;'" title="Editar">
                                 <i class="fas fa-edit"></i>


### PR DESCRIPTION
## Summary

  Implemented full Spring Security integration including authentication,
  authorization, and role-based UI visibility.

  ---

  ### Add the tab for logout

  - Wired the login form (`index.html`) to Spring Security's `/login` endpoint
  with `th:action`, `name="username"`, and `name="password"` fields
  - Added inline feedback messages for login errors (`?error`) and successful
  logout (`?logout`)
  - Added a hidden logout `<form>` in `home.html` posting to `/logout`
  - Displayed the authenticated user's name in the sidebar footer using
  `sec:authentication="name"`
  - Configured logout in `SecurityConfig` to invalidate session, delete
  `JSESSIONID` cookie, and redirect to `/login?logout=true`

  ---

  ### Enable prePostEnabled security roles

  **Backend**

  - Added `spring-boot-starter-security` and `thymeleaf-extras-springsecurity5`
  to `pom.xml`
  - Created `SecurityConfig` extending `WebSecurityConfigurerAdapter` with
  `@EnableGlobalMethodSecurity(prePostEnabled = true)`
  - Created `UserDetailsServiceImpl` loading user + single role as
  `GrantedAuthority` (`ROLE_*` format)
  - Added `BCryptPasswordEncoder` bean; updated `UserServiceImpl` to encode
  passwords on create and change password
  - Created `PasswordMigrationRunner` to detect and re-encode plain-text
  passwords already in the DB on startup
  - Created `RoleInitializer` (`@Order(1)`) to seed the 6 valid roles on startup
   and clean up legacy entries via `JdbcTemplate`
  - Added `@PreAuthorize("hasRole('ADMIN')")` to `createUser`, `putEditUser`,
  `deleteUser`, and `changePassword` in `UserController`
  - Added CSRF meta tags and a global jQuery `$.ajaxSend` hook in `home.html` to
   attach the CSRF token to all AJAX requests
  - Created `RoleConverter` (`String → Role`) and `RoleToStringConverter` (`Role
   → String`) for proper Thymeleaf form binding with `th:field="*{role}"`
  - Changed user–role relationship from `@ManyToMany Set<Role>` to `@ManyToOne
  Role` (single role per user, FK `role_id` directly on `user` table)

  **Frontend (sec:authorize)**

  | Element | Visible to |
  |---|---|
  | Sidebar "Admin" section & "Usuarios" nav link | `ADMIN`, `ANALYST` |
  | "Agregar Usuario" button | `ADMIN` |
  | Actions column (edit / change password / delete) | `ADMIN` |

  **Permission matrix**

  | Feature | ADMIN | ANALYST | DOCTOR | NURSE | RECEPTIONIST | PHARMACIST |
  |---|:---:|:---:|:---:|:---:|:---:|:---:|
  | Ver lista de usuarios | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
  | Crear / Editar / Eliminar usuario | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
  | Cambiar contraseña de usuario | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |